### PR TITLE
Convert checkboxes to dropdowns in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -4,59 +4,59 @@ title: "[BUG]: <Please write a descriptive title after the '[BUG]: ' prefix>"
 labels: [bug]
 
 body:
-- type: markdown
-  attributes:
-    value: >
-      Thank you for taking the time to file a bug report! Before creating a new
-      issue, please make sure to take a few minutes to check the issue tracker
-      for existing issues about the bug.
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to file a bug report! Before creating a new
+        issue, please make sure to take a few minutes to check the issue tracker
+        for existing issues about the bug.
 
-- type: textarea
-  attributes:
-    label: "Issue Description"
-    description: >
-      Please provide a clear and concise description of what the bug is.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Issue Description
+      description: >
+        Please provide a clear and concise description of what the bug is.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Steps to Reproduce"
-    description: >
-      Please provide the steps that should be taken to reproduce the bug.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: >
+        Please provide the steps that should be taken to reproduce the bug.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Expected Behavior"
-    description: >
-      Please describe or show an example of the expected behavior.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: >
+        Please describe or show an example of the expected behavior.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Error Message"
-    description: >
-      Please include the full error message, if any.
-    placeholder: >
-      << Full traceback starting from `Traceback: ...` >>
-    render: bash
+  - type: textarea
+    attributes:
+      label: Error Message
+      description: >
+        Please include the full error message, if any.
+      placeholder: >
+        << Full traceback starting from `Traceback: ...` >>
+      render: bash
 
-- type: textarea
-  attributes:
-    label: "Runtime Environment"
-    description: >
-      Please provide a description of the environment in which the error
-      occurred.
-    placeholder: >
-      Raspberry Pi 4 running Ubuntu 22.04 natively.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Runtime Environment
+      description: >
+        Please provide a description of the environment in which the error
+        occurred.
+      placeholder: >
+        Raspberry Pi 4 running Ubuntu 22.04 natively.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Additional Context"
-    description: >
-      Please provide any additional context needed to understand the bug.
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any additional context needed to understand the bug.

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -4,45 +4,43 @@ title: "[DOC]: <Please write a descriptive title after the '[DOC]: ' prefix>"
 labels: [documentation]
 
 body:
-- type: markdown
-  attributes:
-    value: >
-      Thank you for taking the time to report a documentation issue! Before creating
-      a new issue, please make sure to take a few minutes to check the issue
-      tracker for existing issues similar to that being reported.
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to report a documentation issue! Before creating
+        a new issue, please make sure to take a few minutes to check the issue
+        tracker for existing issues similar to that being reported.
 
-- type: checkboxes
-  attributes:
-    label: Feature Type
-    description: >
-      Please indicate what type of documentation issue you are reporting.
-    options:
-      - label: >
-          Adding new documentation to the Alpha driver documentation
-      - label: >
-          Changing existing Alpha driver documentation
-      - label: >
-          Removing existing Alpha driver documentation
+  - type: dropdown
+    attributes:
+      label: Documentation Change Type
+      description: Please indicate what type of documentation issue you are reporting.
+      options:
+        - Adding new documentation to the Alpha driver documentation
+        - Changing existing Alpha driver documentation
+        - Removing existing Alpha driver documentation
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Documentation Location
-    description: >
-      Please provide the location of the documentation that should be modified.
+  - type: textarea
+    attributes:
+      label: Documentation Location
+      description: >
+        Please provide the location of the documentation that should be modified.
 
-- type: textarea
-  attributes:
-    label: Documentation Problem
-    description: >
-      Please provide a description of how the documentation needs to be improved.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Documentation Problem
+      description: >
+        Please provide a description of how the documentation needs to be improved.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Suggested Change
-    description: >
-      Please provide a description of the proposed change and why the proposed change
-      improves the upon the existing documentation.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Suggested Change
+      description: >
+        Please provide a description of the proposed change and why the proposed change
+        improves the upon the existing documentation.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -4,57 +4,54 @@ title: "[FEATURE]: <Please write a descriptive title after the '[FEATURE]: ' pre
 labels: [enhancement]
 
 body:
-- type: markdown
-  attributes:
-    value: >
-      Thank you for taking the time to request a new feature! Before creating
-      a new issue, please make sure to take a few minutes to check the issue
-      tracker for existing issues similar to the proposed feature.
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to request a new feature! Before creating
+        a new issue, please make sure to take a few minutes to check the issue
+        tracker for existing issues similar to the proposed feature.
 
-- type: checkboxes
-  attributes:
-    label: "Feature Type"
-    description: >
-      Please indicate what type of feature request you would like to propose.
-    options:
-      - label: >
-          Adding new functionality to the Alpha driver
-      - label: >
-          Changing existing functionality in the Alpha driver
-      - label: >
-          Removing existing functionality in the Alpha driver
+  - type: dropdown
+    attributes:
+      label: Feature Type
+      description: Please indicate what type of feature request you would like to propose.
+      options:
+        - Adding new functionality to the Alpha driver
+        - Changing existing functionality in the Alpha driver
+        - Removing existing functionality in the Alpha driver
+    validations:
+      required: true
 
+  - type: textarea
+    attributes:
+      label: Problem Description
+      description: >
+        Please provide a clear and concise description of what problem
+        the feature would solve.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Problem Description"
-    description: >
-      Please provide a clear and concise description of what problem
-      the feature would solve.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Feature Description
+      description: >
+        Please provide a description of the proposed feature, using pseudocode
+        if relevant.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Feature Description"
-    description: >
-      Please provide a description of the proposed feature, using pseudocode
-      if relevant.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Alternative Solutions
+      description: >
+        Please provide a description of any alternative solutions or features
+        that would satisfy the feature request.
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: "Alternative Solutions"
-    description: >
-      Please provide a description of any alternative solutions or features
-      that would satisfy the feature request.
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: "Additional Context"
-    description: >
-      Please provide any additional context (e.g., relevant GitHub issues,
-      code examples, or references) needed to understand the feature request.
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: >
+        Please provide any additional context (e.g., relevant GitHub issues,
+        code examples, or references) needed to understand the feature request.


### PR DESCRIPTION
# Checklist

- [x] I have performed a thorough review of my code
- [x] I have sufficiently commented my code
- [x] The implementation follows the project style conventions
- [x] All project unit tests are passing
- [x] If relevant, documentation has been provided or updated to discuss the changes made
- [x] System integration tests were performed successfully

## Changes Made

This PR converts the previous checkbox-based approach to defining the feature and documentation types to a drop-down style approach.

## Associated Issues

N/A

## Files Changed

- `.github/ISSUE_TEMPLATE/*`: Updated all situations with checkboxes to be dropdowns

## Testing

N/A