### PR TITLE
Fixed ROS 2 Rolling Docker build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -q update \
 
 RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
     && colcon build \
-    --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
     --ament-cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers desktop_notification- status- \
     # Update /ros_entrypoint.sh to source the new workspace


### PR DESCRIPTION
# Checklist

- [x] I have performed a thorough review of my code
- [x] I have sufficiently commented my code
- [x] The implementation follows the project style conventions
- [x] All project unit tests are passing
- [x] If relevant, documentation has been provided or updated to discuss the changes made
- [x] System integration tests were performed successfully

## Changes Made

This PR resolves the ROS 2 Rolling build errors that pop up when building the associated Docker images. The issues were resolved by including `apt-get upgrade`. :roll_eyes: 

## Associated Issues

- Fixes #31 

## Files Changed

- `.docker/Dockerfile`: Updated all apt installations to also include `apt-get upgrade` to ensure that the latest package versions are used.

## Testing

The implemented changes successfully build and can have been tested for dev container development.
