### PR TITLE
Fix xacro for simulation compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ this project to the `src` directory of your ROS workspace, replacing
 `$ROS_DISTRO` with the desired ROS distribution or `main` for Rolling:
 
 ```bash
-git clone -b $ROS_DISTRO git@github.com:evan-palmer/alpha.git
+git clone -b $ROS_DISTRO git@github.com:Robotic-Decision-Making-Lab/alpha.git
 ```
 
 After cloning the project, install the ROS dependencies using `rosdep`, again,

--- a/alpha_bringup/launch/alpha.launch.py
+++ b/alpha_bringup/launch/alpha.launch.py
@@ -112,12 +112,12 @@ def generate_launch_description() -> LaunchDescription:
         ),
         DeclareLaunchArgument(
             "use_planning",
-            default_value="false",
+            default_value="true",
             description="Automatically start the MoveIt2 interface.",
         ),
         DeclareLaunchArgument(
             "use_sim",
-            default_value="false",
+            default_value="true",
             description="Automatically start Gazebo.",
         ),
         DeclareLaunchArgument(

--- a/alpha_description/urdf/alpha.urdf.xacro
+++ b/alpha_description/urdf/alpha.urdf.xacro
@@ -19,7 +19,7 @@
     <link name="${prefix}m3_inline_link">
       <visual>
         <geometry>
-          <mesh filename="package://alpha_description/meshes/M3-INLINE.stl" />
+          <mesh filename="file://$(find alpha_description)/meshes/M3-INLINE.stl" />
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0" />
         <material name="${prefix}black" />
@@ -49,7 +49,7 @@
     <link name="${prefix}m2_1_1_link">
       <visual>
         <geometry>
-          <mesh filename="package://alpha_description/meshes/M2-1-1.stl" />
+          <mesh filename="file://$(find alpha_description)/meshes/M2-1-1.stl" />
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0" />
         <material name="${prefix}black" />
@@ -81,7 +81,7 @@
     <link name="${prefix}m2_joint_link">
       <visual>
         <geometry>
-          <mesh filename="package://alpha_description/meshes/M2.stl" />
+          <mesh filename="file://$(find alpha_description)/meshes/M2.stl" />
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0" />
         <material name="${prefix}black" />
@@ -125,7 +125,7 @@
     <link name="${prefix}m2_1_2_link">
       <visual>
         <geometry>
-          <mesh filename="package://alpha_description/meshes/M2-1-3.stl" />
+          <mesh filename="file://$(find alpha_description)/meshes/M2-1-3.stl" />
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0" />
         <material name="${prefix}black" />
@@ -158,7 +158,7 @@
       <visual>
         <geometry>
           <mesh
-            filename="package://alpha_description/meshes/RS1-100-101-123.stl" />
+            filename="file://$(find alpha_description)/meshes/RS1-100-101-123.stl" />
         </geometry>
         <origin rpy="0 -1.5707 0" xyz="0 0 0" />
         <material name="${prefix}black" />

--- a/alpha_description/urdf/end_effectors/standard_jaws.urdf.xacro
+++ b/alpha_description/urdf/end_effectors/standard_jaws.urdf.xacro
@@ -19,7 +19,7 @@
       <visual>
         <geometry>
           <mesh
-            filename="package://alpha_description/meshes/end_effectors/RS1-124.stl" />
+            filename="file://$(find alpha_description)/meshes/end_effectors/RS1-124.stl" />
         </geometry>
         <material name="${prefix}black" />
       </visual>
@@ -34,7 +34,7 @@
       <visual>
         <geometry>
           <mesh
-            filename="package://alpha_description/meshes/end_effectors/RS1-130.stl" />
+            filename="file://$(find alpha_description)/meshes/end_effectors/RS1-130.stl" />
         </geometry>
         <material name="${prefix}black" />
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -65,7 +65,7 @@
       <visual>
         <geometry>
           <mesh
-            filename="package://alpha_description/meshes/end_effectors/RS1-139.stl" />
+            filename="file://$(find alpha_description)/meshes/end_effectors/RS1-139.stl" />
         </geometry>
         <material name="${prefix}black" />
         <origin xyz="0 0 0" rpy="0 0 0" />


### PR DESCRIPTION
# Checklist

- [X] I have performed a thorough review of my code
- [N/A] I have sufficiently commented my code
- [N/A ] The implementation follows the project style conventions
- [N/A] All project unit tests are passing
- [N/A] If relevant, documentation has been provided or updated to discuss the changes made
- [N/A] System integration tests were performed successfully

## Changes Made

The ```alpha_bringup/launch/alpha.launch.py``` was crashing when using the simulation option. 

As it can be found on the forum [ROS Answers](https://answers.ros.org/question/404423/whats-the-correct-way-to-load-mesh-files-in-gazebo-and-rviz/), the original format ```<mesh filename="package://alpha_description/meshes/[FILE].stl" />``` to call the meshes is not suported by gazebo, just by RVIZ, so the simulation was not working properly. So, it was updated to ```<mesh filename="file://$(find alpha_description)/meshes/[FILE].stl" />```, which support both RVIZ and Gazebo.

The file updeted were ```alpha_description/urdf/end_effectors/standard_jaws.urdf.xacro```
 and ```alpha_description/urdf/alpha.urdf.xacro```

Also, it was found that the README.md instructions pointed for the wrong SSH path and owner of the repository.

## Associated Issues
No associated Issues.

## Testing

The ```alpha_bringup/launch/alpha.launch.py``` was tested both with ```use_sim=true``` and ```use_sim=false```


